### PR TITLE
Makes sure tmp files for tests are deleted even if the tests fail

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 var path = require('path');
-var ConfigGeneraror = require(path.join(__dirname, '../lib/config-generator'));
+var ConfigGenerator = require(path.join(__dirname, '../lib/config-generator'));
 var pkg = require(path.join(__dirname, '../package.json'));
 var program = require('commander');
 var updateNotifier = require('update-notifier');
@@ -33,6 +33,6 @@ program
     .version(require('../package.json').version)
     .parse(process.argv);
 
-var configGenerator = new ConfigGeneraror(program);
+var configGenerator = new ConfigGenerator(program);
 
 configGenerator.process();

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -401,10 +401,10 @@ ConfigGenerator.prototype = {
                     result.push(config);
                 }
 
-                var requireMatch = jsstana.match('(or (call require ?) (call require ? ?) (call require ? ? ?))', node);
+                if (self._options.namespace) {
+                    var requireMatch = jsstana.match('(or (call require ?) (call require ? ?) (call require ? ? ?))', node);
 
-                if (requireMatch) {
-                    if (self._options.namespace) {
+                    if (requireMatch) {
                         node.callee.name = self._options.namespace + '.' + node.callee.name;
 
                         saveFile = true;

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -17,16 +17,16 @@ var builders = recast.types.builders;
 var REGEX_SOURCEMAP = /\/\/#\s+sourceMappingURL\s*=(.+)/;
 
 /**
- * ConfigGeneraror implementation
- * @class ConfigGeneraror
+ * ConfigGenerator implementation
+ * @class ConfigGenerator
  * @param {Object} options Configuration options
  */
-function ConfigGeneraror(options) {
+function ConfigGenerator(options) {
     this._options = options;
 }
 
-ConfigGeneraror.prototype = {
-    constructor: ConfigGeneraror,
+ConfigGenerator.prototype = {
+    constructor: ConfigGenerator,
 
     /**
      * Processes the passed files or folders and generates config file.
@@ -579,4 +579,4 @@ ConfigGeneraror.prototype = {
     }
 };
 
-module.exports = ConfigGeneraror;
+module.exports = ConfigGenerator;

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -331,10 +331,9 @@ ConfigGenerator.prototype = {
 
         return new Promise(function(resolve, reject) {
             var result = [];
+            var saveFile = false;
 
-            jsstana.traverse(ast, function(node) {                
-                var saveFile;
-
+            jsstana.traverse(ast, function(node) {
                 var defineMatch = jsstana.match('(or (call define ?) (call define ? ?) (call define ? ? ?))', node);
 
                 if (defineMatch) {
@@ -411,11 +410,11 @@ ConfigGenerator.prototype = {
                         saveFile = true;
                     }
                 }
-
-                if (saveFile && !self._options.skipFileOverride) {
-                    self._saveFile(file, ast);
-                }
             });
+
+            if (saveFile && !self._options.skipFileOverride) {
+                self._saveFile(file, ast);
+            }
 
             resolve(result);
         });

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -332,12 +332,16 @@ ConfigGeneraror.prototype = {
         return new Promise(function(resolve, reject) {
             var result = [];
 
-            jsstana.traverse(ast, function(node) {
+            jsstana.traverse(ast, function(node) {                
+                var saveFile;
+
                 var defineMatch = jsstana.match('(or (call define ?) (call define ? ?) (call define ? ? ?))', node);
 
                 if (defineMatch) {
                     if (self._options.namespace) {
                         node.callee.name = self._options.namespace + '.' + node.callee.name;
+
+                        saveFile = true;
                     }
 
                     var dependencies;
@@ -356,6 +360,7 @@ ConfigGeneraror.prototype = {
                         // Add the module name.
                         node.arguments.unshift(builders.literal(moduleName));
 
+                        saveFile = true;
                     } else if (node.arguments.length === 2) {
                         // If the first argument is the dependencies, just generate the module name
                         if (node.arguments[0].type === 'ArrayExpression') {
@@ -376,6 +381,7 @@ ConfigGeneraror.prototype = {
                             node.arguments.splice(1, 0, dependencies);
                         }
 
+                        saveFile = true;
                     } else {
                         moduleName = node.arguments[0].value;
                         dependencies = node.arguments[1];
@@ -401,10 +407,12 @@ ConfigGeneraror.prototype = {
                 if (requireMatch) {
                     if (self._options.namespace) {
                         node.callee.name = self._options.namespace + '.' + node.callee.name;
+
+                        saveFile = true;
                     }
                 }
 
-                if (!self._options.skipFileOverride) {
+                if (saveFile && !self._options.skipFileOverride) {
                     self._saveFile(file, ast);
                 }
             });

--- a/test/modal/js/mixed-define-require.es.js
+++ b/test/modal/js/mixed-define-require.es.js
@@ -1,0 +1,3 @@
+define(function(exports) {
+    require(["foo"], function(m) {});
+});

--- a/test/test.js
+++ b/test/test.js
@@ -6,11 +6,27 @@ var path = require('path');
 var fs = require('fs-extra');
 var sinon = require('sinon');
 
+var tmpFileName;
+
 function normalizeCR(content) {
     return content.replace(/\r?\n|\\r/g, '');
 }
 
 describe('ConfigGenerator', function () {
+    afterEach(function(done) {
+        if (tmpFileName) {
+            fs.remove(tmpFileName, function() {
+                done();
+            });
+        } else {
+            done();
+        }
+    });
+
+    beforeEach(function() {
+        tmpFileName = null;
+    });
+
     it('should create config file for module without base config file', function (done) {
         // "format" is being passed here as an array.
         // when passed from command line, this should be passed just as as string, for example:
@@ -229,7 +245,7 @@ describe('ConfigGenerator', function () {
     });
 
     it('should not wrap lines which contain more than 74 characters (the default in Recast)', function (done) {
-        var tmpFileName = path.join(path.resolve(__dirname, 'modal'), 'long-lines-tmp.es.js');
+        tmpFileName = path.join(path.resolve(__dirname, 'modal'), 'long-lines-tmp.es.js');
 
         fs.copy(path.join(path.resolve(__dirname, 'modal'), 'js/long-lines.es.js'), tmpFileName, function(error) {
             if (error) {
@@ -251,15 +267,13 @@ describe('ConfigGenerator', function () {
                     normalizeCR(fs.readFileSync(tmpFileName, 'utf-8'))
                 );
 
-                fs.remove(tmpFileName, function() {
-                    done();
-                });
+                done();
             });
         });
     });
 
     it('should rewrite "define" calls if "namespace" option is present', function (done) {
-        var tmpFileName = path.join(path.resolve(__dirname, 'modal'), 'namespace-define-override.es.tmp.js');
+        tmpFileName = path.join(path.resolve(__dirname, 'modal'), 'namespace-define-override.es.tmp.js');
 
         fs.copy(path.resolve(__dirname, 'modal/js/namespace-define-override.es.js'), tmpFileName, function(error) {
             if (error) {
@@ -284,15 +298,13 @@ describe('ConfigGenerator', function () {
 
                 assert.strictEqual(normalizeCR(actual), normalizeCR(expected));
 
-                fs.remove(tmpFileName, function() {
-                    done();
-                });
+                done();
             });
         });
     });
 
     it('should not rewrite "custom define" calls even if "namespace" option is present', function (done) {
-        var tmpFileName = path.join(path.resolve(__dirname, 'modal'), 'namespace-define-custom.es.tmp.js');
+        tmpFileName = path.join(path.resolve(__dirname, 'modal'), 'namespace-define-custom.es.tmp.js');
         fs.copy(path.resolve(__dirname, 'modal/js/namespace-define-custom.es.js'), tmpFileName, function(error) {
             if (error) {
                 throw error;
@@ -315,15 +327,13 @@ describe('ConfigGenerator', function () {
                 var expected = fs.readFileSync(path.resolve(__dirname, 'expected/expected-namespace-define-custom.es.js'), 'utf-8');
                 assert.strictEqual(normalizeCR(actual), normalizeCR(expected));
 
-                fs.remove(tmpFileName, function() {
-                    done();
-                });
+                done();
             });
         });
     });
 
     it('should rewrite "require" calls if "namespace" option is present', function (done) {
-        var tmpFileName = path.resolve(path.resolve(__dirname, 'modal'), 'namespace-require-override.es.tmp.js');
+        tmpFileName = path.resolve(path.resolve(__dirname, 'modal'), 'namespace-require-override.es.tmp.js');
 
         fs.copy(path.resolve(__dirname, 'modal/js/namespace-require-override.es.js'), tmpFileName, function(error) {
             if (error) {
@@ -348,15 +358,13 @@ describe('ConfigGenerator', function () {
 
                 assert.strictEqual(normalizeCR(actual), normalizeCR(expected));
 
-                fs.remove(tmpFileName, function() {
-                    done();
-                });
+                done();
             });
         });
     });
 
     it('should not rewrite "custom require" calls even if "namespace" option is present', function (done) {
-        var tmpFileName = path.resolve(path.resolve(__dirname, 'modal'), 'namespace-require-custom.es.tmp.js');
+        tmpFileName = path.resolve(path.resolve(__dirname, 'modal'), 'namespace-require-custom.es.tmp.js');
 
         fs.copy(path.resolve(__dirname, 'modal/js/namespace-require-custom.es.js'), tmpFileName, function(error) {
             if (error) {
@@ -378,17 +386,15 @@ describe('ConfigGenerator', function () {
             configGenerator.process().then(function(config) {
                 var actual = fs.readFileSync(tmpFileName, 'utf-8');
                 var expected = fs.readFileSync(path.resolve(__dirname, 'expected/expected-namespace-require-custom.es.js'), 'utf-8');
-                assert.strictEqual(normalizeCR(actual), normalizeCR(expected));
+                assert.strictEqual(normalizeCR(actual), normalizeCR('expected'));
 
-                fs.remove(tmpFileName, function() {
-                    done();
-                });
+                done();
             });
         });
     });
 
     it('should save a modified file only once', function(done) {
-        var tmpFileName = path.resolve(path.resolve(__dirname, 'modal'), 'mixed-define-require.es.tmp.js');
+        tmpFileName = path.resolve(path.resolve(__dirname, 'modal'), 'mixed-define-require.es.tmp.js');
 
         fs.copy(path.resolve(__dirname, 'modal/js/mixed-define-require.es.js'), tmpFileName, function(error) {
             if (error) {
@@ -412,9 +418,7 @@ describe('ConfigGenerator', function () {
             configGenerator.process().then(function(config) {
                 assert.strictEqual(spy.callCount, 1);
 
-                fs.remove(tmpFileName, function() {
-                    done();
-                });
+                done();
             });
         });
     });


### PR DESCRIPTION
This is a fix for #37, it makes sure tests tmp files are deleted `afterEach` test execution.

@ipeychev, I based this on the previous https://github.com/liferay/liferay-module-config-generator/pull/38 to make sure I also updated the tests in there.